### PR TITLE
chore: add package-lock.json

### DIFF
--- a/.github/workflows/generate-lockfile.yml
+++ b/.github/workflows/generate-lockfile.yml
@@ -1,0 +1,35 @@
+name: Generate package-lock.json
+
+on:
+  push:
+    branches:
+      - chore/add-lockfile
+
+jobs:
+  generate-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install npm dependencies to generate lockfile
+        run: npm install --package-lock-only
+
+      - name: Commit and push package-lock.json
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "ci: generate package-lock.json"
+            git push origin HEAD:chore/add-lockfile
+          fi


### PR DESCRIPTION
Add package-lock.json so CI and Render can use npm ci for deterministic installs. Linked to issue #17.